### PR TITLE
chore: bump form-data to >=4.0.4 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
     "husky": "^9.1.7",
     "prettier": "^3.5.3",
     "typescript": "5.8.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data": ">=4.0.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: '>=4.0.4'
+
 importers:
 
   .:

--- a/zephyr-examples/create-mf-app-rspack/package.json
+++ b/zephyr-examples/create-mf-app-rspack/package.json
@@ -27,5 +27,10 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zephyr-rspack-plugin": "^0.0.54"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data": ">=4.0.4"
+    }
   }
 }

--- a/zephyr-examples/create-mf-app-rspack/pnpm-lock.yaml
+++ b/zephyr-examples/create-mf-app-rspack/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: '>=4.0.4'
+
 importers:
 
   .:
@@ -808,8 +811,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
@@ -2019,7 +2022,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 22.13.13
-      form-data: 4.0.2
+      form-data: 4.0.4
 
   '@types/node-forge@1.3.11':
     dependencies:
@@ -2225,7 +2228,7 @@ snapshots:
   axios@1.10.0(debug@4.4.0):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.0)
-      form-data: 4.0.2
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -2605,11 +2608,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   formdata-node@4.4.1:


### PR DESCRIPTION
## Summary
- Added pnpm override to force form-data version to >=4.0.4 to address security vulnerability in previous version
- Updated both root and example package.json files

## Test plan
- [x] Updated package.json files with pnpm override
- [x] Verified dependencies are updated correctly
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)